### PR TITLE
Better default values + sha256 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .hypothesis
+dist/

--- a/pyodide_lock/spec.py
+++ b/pyodide_lock/spec.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Extra
 
+from .utils import _generate_package_hash
+
 
 class InfoSpec(BaseModel):
     arch: Literal["wasm32", "wasm64"] = "wasm32"
@@ -20,7 +22,7 @@ class PackageSpec(BaseModel):
     version: str
     file_name: str
     install_dir: str
-    sha256: str
+    sha256: str = ""
     package_type: Literal[
         "package", "cpython_module", "shared_library", "static_library"
     ] = "package"
@@ -32,6 +34,11 @@ class PackageSpec(BaseModel):
 
     class Config:
         extra = Extra.forbid
+
+    def update_sha256(self, path: Path) -> "PackageSpec":
+        """Update the sha256 hash for a package."""
+        self.sha256 = _generate_package_hash(path)
+        return self
 
 
 class PyodideLockSpec(BaseModel):

--- a/pyodide_lock/spec.py
+++ b/pyodide_lock/spec.py
@@ -57,7 +57,7 @@ class PyodideLockSpec(BaseModel):
             data = json.load(fh)
         return cls(**data)
 
-    def to_json(self, json_path: Path, indent: int = 0) -> None:
+    def to_json(self, path: Path, indent: int = 0) -> None:
         """Write the lock spec to a json file."""
-        with json_path.open("w") as fh:
+        with path.open("w") as fh:
             json.dump(self.dict(), fh, indent=indent)

--- a/pyodide_lock/spec.py
+++ b/pyodide_lock/spec.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Extra
 
 
 class InfoSpec(BaseModel):
-    arch: str
+    arch: Literal["wasm32", "wasm64"] = "wasm32"
     platform: str
     version: str
     python: str
@@ -24,8 +24,8 @@ class PackageSpec(BaseModel):
     package_type: Literal[
         "package", "cpython_module", "shared_library", "static_library"
     ] = "package"
-    imports: list[str]
-    depends: list[str]
+    imports: list[str] = []
+    depends: list[str] = []
     unvendored_tests: bool = False
     # This field is deprecated
     shared_library: bool = False
@@ -44,13 +44,13 @@ class PyodideLockSpec(BaseModel):
         extra = Extra.forbid
 
     @classmethod
-    def from_json(cls, json_path: Path):
+    def from_json(cls, path: Path) -> "PyodideLockSpec":
         """Read the lock spec from a json file."""
-        with json_path.open("r") as fh:
+        with path.open("r") as fh:
             data = json.load(fh)
         return cls(**data)
 
-    def to_json(self, json_path: Path, indent: int = 0):
+    def to_json(self, json_path: Path, indent: int = 0) -> None:
         """Write the lock spec to a json file."""
         with json_path.open("w") as fh:
             json.dump(self.dict(), fh, indent=indent)

--- a/pyodide_lock/utils.py
+++ b/pyodide_lock/utils.py
@@ -1,0 +1,20 @@
+import hashlib
+from pathlib import Path
+
+
+def _generate_package_hash(full_path: Path) -> str:
+    """Generate a sha256 hash for a package
+
+    Examples
+    --------
+    >>> tmp_path = getfixture("tmp_path")
+    >>> input_path = tmp_path / "a.txt"
+    >>> _ = input_path.write_text("foo")
+    >>> _generate_package_hash(input_path)
+    '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae'
+    """
+    sha256_hash = hashlib.sha256()
+    with open(full_path, "rb") as f:
+        while chunk := f.read(4096):
+            sha256_hash.update(chunk)
+    return sha256_hash.hexdigest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,7 @@ select = [
   "PLE",    # pylint errors
   "UP",     # pyupgrade
 ]
+
+[tool.pytest.ini_options]
+addopts = '''
+--doctest-modules'''


### PR DESCRIPTION
Adds more default values so this spec is easier to use in pyodide-build. 

Also moves the sha256 calculation logic from pyodide-build here, so it can be also reused in other packages.