### PR TITLE
Add check_wheel_filenames method to PyodideLockSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.9  - 2023-07-21
+## 0.1.0  - 2023-07-21
 
 Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.9  - 2023-07-21
 
 Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0  - 2023-07-21
+## [0.1.0a2] - 2023-07-21
+
+### Added
+ - Add `check_wheel_filenames` method to `PyodideLockSpec` that checks that the
+   package name in version are consistent between the wheel filename and the
+   corresponding pyodide-lock.json fields
+   [#11](https://github.com/pyodide/pyodide-lock/pull/11)
+
+## [0.1.0a1] - 2023-06-23
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI Latest Release](https://img.shields.io/pypi/v/pyodide-lock.svg)](https://pypi.org/project/pyodide-lock/)
 ![GHA](https://github.com/pyodide/pyodide-lock/actions/workflows/main.yml/badge.svg)
+[![codecov](https://codecov.io/gh/pyodide/pyodide-lock/branch/main/graph/badge.svg?token=T0UEJW2F2P)](https://codecov.io/gh/pyodide/pyodide-lock)
 
 Tooling to manage the `pyodide-lock.json` file.
 

--- a/pyodide_lock/spec.py
+++ b/pyodide_lock/spec.py
@@ -62,7 +62,7 @@ class PyodideLockSpec(BaseModel):
         with path.open("w") as fh:
             json.dump(self.dict(), fh, indent=indent)
 
-    def check_wheel_filenames(self) -> dict[str, list[str]]:
+    def check_wheel_filenames(self) -> None:
         """Check that the package name and version are consistent in wheel filenames"""
         from packaging.utils import (
             canonicalize_name,
@@ -86,4 +86,11 @@ class PyodideLockSpec(BaseModel):
                     f"does not match package version "
                     f"{canonicalize_version(spec.version)!r}"
                 )
-        return errors
+        if errors:
+            error_msg = "check_wheel_filenames failed:\n"
+
+            error_msg += "  - " + "\n  - ".join(
+                f"{name}:\n    - " + "\n    - ".join(errs)
+                for name, errs in errors.items()
+            )
+            raise ValueError(error_msg)

--- a/pyodide_lock/spec.py
+++ b/pyodide_lock/spec.py
@@ -61,3 +61,29 @@ class PyodideLockSpec(BaseModel):
         """Write the lock spec to a json file."""
         with path.open("w") as fh:
             json.dump(self.dict(), fh, indent=indent)
+
+    def check_wheel_filenames(self) -> dict[str, list[str]]:
+        """Check that the package name and version are consistent in wheel filenames"""
+        from packaging.utils import (
+            canonicalize_name,
+            canonicalize_version,
+            parse_wheel_filename,
+        )
+
+        errors: dict[str, list[str]] = {}
+        for name, spec in self.packages.items():
+            if not spec.file_name.endswith(".whl"):
+                continue
+            name_in_wheel, ver, _, _ = parse_wheel_filename(spec.file_name)
+            if canonicalize_name(name_in_wheel) != canonicalize_name(spec.name):
+                errors.setdefault(name, []).append(
+                    f"Package name in wheel filename {name_in_wheel!r} "
+                    f"does not match {spec.name!r}"
+                )
+            if canonicalize_version(ver) != canonicalize_version(spec.version):
+                errors.setdefault(name, []).append(
+                    f"Version in the wheel filename {canonicalize_version(ver)!r} "
+                    f"does not match package version "
+                    f"{canonicalize_version(spec.version)!r}"
+                )
+        return errors

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,5 +1,6 @@
 import gzip
 import shutil
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,28 @@ import pytest
 from pyodide_lock import PyodideLockSpec
 
 DATA_DIR = Path(__file__).parent / "data"
+
+LOCK_EXAMPLE = {
+    "info": {
+        "arch": "wasm32",
+        "platform": "emscripten_3_1_39",
+        "version": "0.24.0.dev0",
+        "python": "3.11.3",
+    },
+    "packages": {
+        "numpy": {
+            "name": "numpy",
+            "version": "1.24.3",
+            "file_name": "numpy-1.24.3-cp311-cp311-emscripten_3_1_39_wasm32.whl",
+            "install_dir": "site",
+            "sha256": (
+                "513af43ffb1f7d507c8d879c9f7e5" "d6c789ad21b6a67e5bca1d7cfb86bf8640f"
+            ),
+            "imports": ["numpy"],
+            "depends": [],
+        }
+    },
+}
 
 
 @pytest.mark.parametrize("pyodide_version", ["0.22.1", "0.23.3"])
@@ -31,28 +54,7 @@ def test_lock_spec_parsing(pyodide_version, tmp_path):
 
 
 def test_check_wheel_filenames():
-    lock_data = {
-        "info": {
-            "arch": "wasm32",
-            "platform": "emscripten_3_1_39",
-            "version": "0.24.0.dev0",
-            "python": "3.11.3",
-        },
-        "packages": {
-            "numpy": {
-                "name": "numpy",
-                "version": "1.24.3",
-                "file_name": "numpy-1.24.3-cp311-cp311-emscripten_3_1_39_wasm32.whl",
-                "install_dir": "site",
-                "sha256": (
-                    "513af43ffb1f7d507c8d879c9f7e5"
-                    "d6c789ad21b6a67e5bca1d7cfb86bf8640f"
-                ),
-                "imports": ["numpy"],
-                "depends": [],
-            }
-        },
-    }
+    lock_data = deepcopy(LOCK_EXAMPLE)
 
     spec = PyodideLockSpec(**lock_data)
     assert spec.check_wheel_filenames() == {}
@@ -72,3 +74,14 @@ def test_check_wheel_filenames():
             "package version '0.2.3'",
         ]
     }
+
+
+def test_update_sha256(monkeypatch):
+    monkeypatch.setattr("pyodide_lock.spec._generate_package_hash", lambda x: "abcd")
+    lock_data = deepcopy(LOCK_EXAMPLE)
+
+    lock_data["packages"]["numpy"]["sha256"] = "0"  # type: ignore[index]
+    spec = PyodideLockSpec(**lock_data)
+    assert spec.packages["numpy"].sha256 == "0"
+    spec.packages["numpy"].update_sha256(Path("/some/path"))
+    assert spec.packages["numpy"].sha256 == "abcd"

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -57,23 +57,27 @@ def test_check_wheel_filenames():
     lock_data = deepcopy(LOCK_EXAMPLE)
 
     spec = PyodideLockSpec(**lock_data)
-    assert spec.check_wheel_filenames() == {}
+    spec.check_wheel_filenames()
 
     lock_data["packages"]["numpy"]["name"] = "numpy2"  # type: ignore[index]
     spec = PyodideLockSpec(**lock_data)
-    assert spec.check_wheel_filenames() == {
-        "numpy": ["Package name in wheel filename 'numpy' does not match 'numpy2'"]
-    }
+    msg = (
+        ".*check_wheel_filenames failed.*\n.*numpy:\n.*"
+        "Package name in wheel filename 'numpy' does not match 'numpy2'"
+    )
+    with pytest.raises(ValueError, match=msg):
+        spec.check_wheel_filenames()
 
     lock_data["packages"]["numpy"]["version"] = "0.2.3"  # type: ignore[index]
     spec = PyodideLockSpec(**lock_data)
-    assert spec.check_wheel_filenames() == {
-        "numpy": [
-            "Package name in wheel filename 'numpy' does not match 'numpy2'",
-            "Version in the wheel filename '1.24.3' does not match "
-            "package version '0.2.3'",
-        ]
-    }
+    msg = (
+        ".*check_wheel_filenames failed.*\n.*numpy:\n.*"
+        "Package name in wheel filename 'numpy' does not match 'numpy2'\n.*"
+        "Version in the wheel filename '1.24.3' does not match "
+        "package version '0.2.3'"
+    )
+    with pytest.raises(ValueError, match=msg):
+        spec.check_wheel_filenames()
 
 
 def test_update_sha256(monkeypatch):


### PR DESCRIPTION
Add the `check_wheel_filenames` method to `PyodideLockSpec` that checks that the package name in version are consistent between the wheel filename and the corresponding `pyodide-lock.json` fields.

Pyodide installers don't care about this, but if we expose a Simple JSON API, pip for instance will reject packages if the package name doesn't match in the wheel filename https://github.com/pyodide/pyodide/issues/3979#issuecomment-1644618784

I also didn't do this as part of the pydantic validation, otherwise `pyodide-lock.json`  will fail to parse for past stable releases as there are a couple packages where this is not the case.