### PR TITLE
Change the default value of indent argument in `to_json` to `None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `PyodideLockSpec.to_json` to not add newlines to the output by default.
+  [#12](https://github.com/pyodide/pyodide-lock/pull/12)
+
 ## [0.1.0a2] - 2023-07-21
 
 ### Added

--- a/pyodide_lock/spec.py
+++ b/pyodide_lock/spec.py
@@ -57,7 +57,7 @@ class PyodideLockSpec(BaseModel):
             data = json.load(fh)
         return cls(**data)
 
-    def to_json(self, path: Path, indent: int = 0) -> None:
+    def to_json(self, path: Path, indent: int | None = None) -> None:
         """Write the lock spec to a json file."""
         with path.open("w") as fh:
             json.dump(self.dict(), fh, indent=indent)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -80,6 +80,22 @@ def test_check_wheel_filenames():
         spec.check_wheel_filenames()
 
 
+def test_to_json_indent(tmp_path):
+    lock_data = deepcopy(LOCK_EXAMPLE)
+    target_path = tmp_path / "pyodide-lock.json"
+
+    spec = PyodideLockSpec(**lock_data)
+    spec.to_json(target_path)
+    
+    assert "\n" not in target_path.read_text()
+
+    spec.to_json(target_path, indent=0)
+    assert "\n" in target_path.read_text()
+
+    spec.to_json(target_path, indent=2)
+    assert "\n" in target_path.read_text()
+
+
 def test_update_sha256(monkeypatch):
     monkeypatch.setattr("pyodide_lock.spec._generate_package_hash", lambda x: "abcd")
     lock_data = deepcopy(LOCK_EXAMPLE)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -86,7 +86,7 @@ def test_to_json_indent(tmp_path):
 
     spec = PyodideLockSpec(**lock_data)
     spec.to_json(target_path)
-    
+
     assert "\n" not in target_path.read_text()
 
     spec.to_json(target_path, indent=0)


### PR DESCRIPTION
The default value of the `indent` argument in the `to_json` method is set to 0, which outputs a JSON file with newline characters but no indentation. You can check this in: https://cdn.jsdelivr.net/pyodide/dev/full/pyodide-lock.json

![image](https://github.com/pyodide/pyodide-lock/assets/24893111/cea13c6d-7776-4d6b-bdd9-a0b999eb8ba4)

This PR changes the default value to None, so no newline characters are included in the output.


