### PR TITLE
Update package home/issues URL metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dev = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/pyodide-lock/pyodide-lock"
-"Bug Tracker" = "https://github.com/pyodide-lock/pyodide-lock/issues"
+"Homepage" = "https://github.com/pyodide/pyodide-lock"
+"Bug Tracker" = "https://github.com/pyodide/pyodide-lock/issues"
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
Thanks for `pyodide-lock`!

This PR updates the `pyproject.toml` with some more accurate metadata.

Motivation: i'm looking to get this packaged on conda-forge to support `pyodide-build 0.24.0`, and noticed this little bit.

Links:
- https://github.com/conda-forge/pyodide-build-feedstock/pull/6
- https://github.com/conda-forge/staged-recipes/pull/23982

Thanks again!