### PR TITLE
Port parse_top_level_import_name from pyodide-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
+.coverage
 .hypothesis
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Adds `parse_top_level_import_name` for finding importable names in `.whl` files
+  [#17](https://github.com/pyodide/pyodide-lock/pull/17)
+
 ## [0.1.0a3] - 2023-09-15
 
 ### Fixed

--- a/pyodide_lock/__init__.py
+++ b/pyodide_lock/__init__.py
@@ -1,3 +1,7 @@
 from .spec import PyodideLockSpec
+from .utils import parse_top_level_import_name
 
-__all__ = ["PyodideLockSpec"]
+__all__ = [
+    "PyodideLockSpec",
+    "parse_top_level_import_name",
+]

--- a/pyodide_lock/utils.py
+++ b/pyodide_lock/utils.py
@@ -1,5 +1,58 @@
 import hashlib
+import logging
+import zipfile
+from collections import deque
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def parse_top_level_import_name(whlfile: Path) -> list[str] | None:
+    """
+    Parse the top-level import names from a wheel file.
+    """
+
+    if not whlfile.name.endswith(".whl"):
+        raise RuntimeError(f"{whlfile} is not a wheel file.")
+
+    whlzip = zipfile.Path(whlfile)
+
+    # If there is no top_level.txt file, we will find top level imports by
+    # 1) a python file on a top-level directory
+    # 2) a sub directory with __init__.py
+    # following: https://github.com/pypa/setuptools/blob/d680efc8b4cd9aa388d07d3e298b870d26e9e04b/setuptools/discovery.py#L122
+    top_level_imports = []
+    for subdir in whlzip.iterdir():
+        if subdir.is_file() and subdir.name.endswith(".py"):
+            top_level_imports.append(subdir.name[:-3])
+        elif subdir.is_dir() and _valid_package_name(subdir.name):
+            if _has_python_file(subdir):
+                top_level_imports.append(subdir.name)
+
+    if not top_level_imports:
+        logger.warning(
+            f"WARNING: failed to parse top level import name from {whlfile}."
+        )
+        return None
+
+    return top_level_imports
+
+
+def _valid_package_name(dirname: str) -> bool:
+    return all([invalid_chr not in dirname for invalid_chr in ".- "])
+
+
+def _has_python_file(subdir: zipfile.Path) -> bool:
+    queue = deque([subdir])
+    while queue:
+        nested_subdir = queue.pop()
+        for subfile in nested_subdir.iterdir():
+            if subfile.is_file() and subfile.name.endswith(".py"):
+                return True
+            elif subfile.is_dir() and _valid_package_name(subfile.name):
+                queue.append(subfile)
+
+    return False
 
 
 def _generate_package_hash(full_path: Path) -> str:

--- a/pyodide_lock/utils.py
+++ b/pyodide_lock/utils.py
@@ -10,6 +10,9 @@ logger = logging.getLogger(__name__)
 def parse_top_level_import_name(whlfile: Path) -> list[str] | None:
     """
     Parse the top-level import names from a wheel file.
+
+    While this behavior matches the way ``setuptools`` creates ``top_level.txt``,
+    some cases, such as PEP 420 namespace packages, may not be handled correctly.
     """
 
     if not whlfile.name.endswith(".whl"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,57 @@
+import zipfile
+
+import pytest
+
+from pyodide_lock import parse_top_level_import_name
+
+
+@pytest.mark.parametrize(
+    "pkg",
+    [
+        {
+            "name": "pkg_singlefile-1.0.0-py3-none-any.whl",
+            "file": "singlefile.py",
+            "content": "pass\n",
+            "top_level": ["singlefile"],
+        },
+        {
+            "name": "pkg_flit-1.0.0-py3-none-any.whl",
+            "file": "pkg_flit/__init__.py",
+            "content": "pass\n",
+            "top_level": ["pkg_flit"],
+        },
+        {
+            "name": "pkg_ruamel_yaml_dingdong-1.0.0-py3-none-any.whl",
+            "file": "pkg_ruamel/yaml/ding/dong/__init__.py",
+            "content": "pass\n",
+            "top_level": ["pkg_ruamel"],
+        },
+        {
+            "name": "bad_no_python-1.0.0-py3-none-any.whl",
+            "file": "no/python/README.md",
+            "content": "pass\n",
+            "top_level": None,
+        },
+        {
+            "name": "bad_spaces-1.0.0-py3-none-any.whl",
+            "file": "space in path/README.md",
+            "content": "pass\n",
+            "top_level": None,
+        },
+    ],
+)
+def test_top_level_imports(pkg, tmp_path):
+    with zipfile.ZipFile(tmp_path / pkg["name"], "w") as whlzip:
+        whlzip.writestr(pkg["file"], data=pkg["content"])
+
+    top_level = parse_top_level_import_name(tmp_path / pkg["name"])
+    assert top_level == pkg["top_level"]
+
+
+def test_not_wheel(tmp_path):
+    path = tmp_path / "pkg.zip"
+    with zipfile.ZipFile(path, "w") as whlzip:
+        whlzip.writestr("README.md", data="#")
+
+    with pytest.raises(RuntimeError, match="not a wheel"):
+        parse_top_level_import_name(path)


### PR DESCRIPTION
## References
- fixes #7

## Changes
- ports `parse_top_level_import_name`

## Questions
- presumably there's no license issues, etc.?
- could go someplace else?
- niggling thing in the back of my mind is [PEP 420](https://peps.python.org/pep-0420/) packages, e.g. `ruamel.yaml`
  - these probably don't work at all today... the `top_level.txt` of existing files (such as `ruamel.yaml`) would not work with the autoimport mechanism