### PR TITLE
Add PackageSpec.from_wheel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
+    - name: Build
+      run: |
+        pyproject-build
     - name: Test with pytest
       run: |
         pytest --cov=. --cov-report=xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds `PackageSpec.from_wheel` for generating a package spec from a `.whl` file
+  [#18](https://github.com/pyodide/pyodide-lock/pull/18)
 - Adds `parse_top_level_import_name` for finding importable names in `.whl` files
   [#17](https://github.com/pyodide/pyodide-lock/pull/17)
 

--- a/pyodide_lock/__init__.py
+++ b/pyodide_lock/__init__.py
@@ -1,7 +1,8 @@
-from .spec import PyodideLockSpec
+from .spec import PackageSpec, PyodideLockSpec
 from .utils import parse_top_level_import_name
 
 __all__ = [
     "PyodideLockSpec",
+    "PackageSpec",
     "parse_top_level_import_name",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,28 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+wheel = [
+    "pkginfo",
+    "packaging",
+]
 dev = [
-    "pytest", "pytest-cov"
+    "pytest",
+    "pytest-cov",
+    "build",
+    # from wheel
+    "pkginfo",
+    "packaging",
 ]
 
 [project.urls]
 "Homepage" = "https://github.com/pyodide/pyodide-lock"
 "Bug Tracker" = "https://github.com/pyodide/pyodide-lock/issues"
+
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+]
 
 [tool.hatch.version]
 source = "vcs"

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -1,0 +1,42 @@
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from pyodide_lock import PackageSpec
+from pyodide_lock.utils import _generate_package_hash
+
+HERE = Path(__file__).parent
+DIST = HERE.parent / "dist"
+WHEEL = next(DIST.glob("*.whl")) if DIST.exists() else None
+
+
+@pytest.mark.skipif(WHEEL is None, reason="wheel test requires a built wheel")
+def test_self_wheel():
+    assert WHEEL is not None
+
+    spec = PackageSpec.from_wheel(WHEEL).model_dump_json(indent=2)
+
+    expected = PackageSpec(
+        name="pyodide-lock",
+        version=WHEEL.name.split("-")[1],
+        file_name=WHEEL.name,
+        install_dir="site",
+        sha256=_generate_package_hash(WHEEL),
+        package_type="package",
+        imports=["pyodide_lock"],
+        depends=["pydantic"],
+        unvendored_tests=False,
+        shared_library=False,
+    ).model_dump_json(indent=2)
+
+    assert spec == expected
+
+
+def test_not_wheel(tmp_path):
+    wheel = tmp_path / "not-a-wheel-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as whlzip:
+        whlzip.writestr("README.md", data="Not a wheel")
+
+    with pytest.raises(RuntimeError, match="metadata"):
+        PackageSpec.from_wheel(wheel)


### PR DESCRIPTION
## References
- for #9
- ported from https://github.com/jupyterlite/pyodide-kernel/pull/27

## Changes
- [x] adds `PackageSpec.from_wheel`
- [x] build wheel before test in CI (it's used in the test) 
- [x] update changelog

## Questions
- is this even the right way to go?
- while self-testing the wheel is cute, perhaps real fixtures would be better?