### PR TITLE
CI trigger on any branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
 
 name: CI
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: ["push", "pull_request"]
 
 permissions:
   contents: read


### PR DESCRIPTION
This might be the reason why deployment to PyPI was skipped (https://github.com/pyodide/pyodide-lock/issues/14), though I'm not sure.
In particular, by filtering only to the main branch, it's possible that when a tag was pushed, CI was then not triggered.

At least this gets the setup to be closer to micropip, which is known to be working. Otherwise that CI job definition is identical to micropip.