### PR TITLE
Pin to `pydantic <2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Adds `PackageSpec.from_wheel` for generating a package spec from a `.whl` file
+- Pinned to `pydantic >=1.10.2,<2`
+  [#23](https://github.com/pyodide/pyodide-lock/pull/23)
+
+- Added `PackageSpec.from_wheel` for generating a package spec from a `.whl` file
   [#18](https://github.com/pyodide/pyodide-lock/pull/18)
-- Adds `parse_top_level_import_name` for finding importable names in `.whl` files
+
+- Added `parse_top_level_import_name` for finding importable names in `.whl` files
   [#17](https://github.com/pyodide/pyodide-lock/pull/17)
 
 ## [0.1.0a3] - 2023-09-15
@@ -26,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0a2] - 2023-07-21
 
 ### Added
+
  - Add `check_wheel_filenames` method to `PyodideLockSpec` that checks that the
    package name in version are consistent between the wheel filename and the
    corresponding pyodide-lock.json fields

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "Tooling to manage the `pyodide-lock.json` file"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    # compatible with pyodide-build, and the as-shipped wheel in the pyodide distributiont
+    # compatible with pyodide-build and the as-shipped wheel in the pyodide distribution
     "pydantic >=1.10.2,<2",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ description = "Tooling to manage the `pyodide-lock.json` file"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-   "pydantic"
+    # compatible with pyodide-build, and the as-shipped wheel in the pyodide distributiont
+    "pydantic >=1.10.2,<2",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -119,11 +119,11 @@ def test_extra_config_forbidden():
     info_data["extra"] = "extra"  # type: ignore[index]
     package_data["extra"] = "extra"
 
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+    with pytest.raises(ValidationError, match="extra fields not permitted"):
         PyodideLockSpec(**lock_data)
 
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+    with pytest.raises(ValidationError, match="extra fields not permitted"):
         InfoSpec(**info_data)  # type: ignore[arg-type]
 
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+    with pytest.raises(ValidationError, match="extra fields not permitted"):
         PackageSpec(**package_data)

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -46,7 +46,7 @@ NOT_NUM_MARKER_EXAMPLES: "TDepExamples" = {
 def test_self_wheel():
     assert WHEEL is not None
 
-    spec = PackageSpec.from_wheel(WHEEL).model_dump_json(indent=2)
+    spec = PackageSpec.from_wheel(WHEEL).json(indent=2, sort_keys=True)
 
     expected = PackageSpec(
         name="pyodide-lock",
@@ -59,7 +59,7 @@ def test_self_wheel():
         depends=["pydantic"],
         unvendored_tests=False,
         shared_library=False,
-    ).model_dump_json(indent=2)
+    ).json(indent=2, sort_keys=True)
 
     assert spec == expected
 


### PR DESCRIPTION
## References

- fixes #22
- important for #3
- mentioned in https://github.com/pyodide/pyodide/issues/4182#issuecomment-1737311687

## Changes

- [x] adds `pydantic` pin in `pyproject.toml`
- [x] use `pydantic 1.x` API
  - [x] model dumping
  - [x] use nested `Config` class instead of `ConfigDict`
- [x] fix tests
  - [x] more model dumping 
  - [x] update magic strings 
- [x] changelog 