### PR TITLE
Support abi3 wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.0a8] - 2024-09-17
+
+### Added
+
 - Support stable ABI (`abi3`) wheels in lock file.
   [#32](https://github.com/pyodide/pyodide-lock/pull/32)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+- Support stable ABI (`abi3`) wheels in lock file.
+  [#32](https://github.com/pyodide/pyodide-lock/pull/32)
 
 ## [0.1.0a7] - 2024-08-08
 
@@ -57,10 +61,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
- - Add `check_wheel_filenames` method to `PyodideLockSpec` that checks that the
-   package name in version are consistent between the wheel filename and the
-   corresponding pyodide-lock.json fields
-   [#11](https://github.com/pyodide/pyodide-lock/pull/11)
+- Add `check_wheel_filenames` method to `PyodideLockSpec` that checks that the
+  package name in version are consistent between the wheel filename and the
+  corresponding pyodide-lock.json fields
+  [#11](https://github.com/pyodide/pyodide-lock/pull/11)
 
 ## [0.1.0a1] - 2023-06-23
 

--- a/pyodide_lock/utils.py
+++ b/pyodide_lock/utils.py
@@ -321,6 +321,9 @@ def _check_wheel_compatible(path: Path, info: InfoSpec) -> None:
         raise RuntimeError(f"Wheel filename {path.name} is not valid") from e
     python_binary_abi = f"cp{target_python.major}{target_python.minor}"
     tags = list(tags)
+    abi3_compat = {
+        f"cp{target_python.major}{minor}" for minor in range(target_python.minor + 1)
+    }
 
     tag_match = False
     for t in tags:
@@ -330,6 +333,8 @@ def _check_wheel_compatible(path: Path, info: InfoSpec) -> None:
             and t.interpreter == python_binary_abi
             and t.platform == target_platform
         ):
+            tag_match = True
+        elif t.abi == "abi3" and t.interpreter in abi3_compat:
             tag_match = True
         elif t.abi == "none" and t.platform == "any":
             match = re.match(rf"py{target_python.major}(\d*)", t.interpreter)

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -169,12 +169,30 @@ def test_wheel_compatibility_checking(example_lock_spec):
         Path(f"test_wheel-1.0.0-{cpython_tag}-{cpython_tag}-{emscripten_tag}.whl"),
         example_lock_spec.info,
     )
+    # abi3, current version
+    _check_wheel_compatible(
+        Path(f"test_wheel-1.0.0-{cpython_tag}-abi3-{emscripten_tag}.whl"),
+        example_lock_spec.info,
+    )
+    # abi3, past version
+    past_cpython_tag = f"cp{target_python.major}{target_python.minor-1}"
+    _check_wheel_compatible(
+        Path(f"test_wheel-1.0.0-{past_cpython_tag}-abi3-{emscripten_tag}.whl"),
+        example_lock_spec.info,
+    )
     with pytest.raises(RuntimeError):
         # cpython emscripten incorrect version
         _check_wheel_compatible(
             Path(
                 f"test_wheel-1.0.0-{cpython_tag}-{cpython_tag}-emscripten_3_1_2_wasm32.whl"
             ),
+            example_lock_spec.info,
+        )
+    with pytest.raises(RuntimeError):
+        # abi3, interpreter version too large
+        future_cpython_tag = f"cp{target_python.major}{target_python.minor+1}"
+        _check_wheel_compatible(
+            Path(f"test_wheel-1.0.0-{future_cpython_tag}-abi3-{emscripten_tag}.whl"),
             example_lock_spec.info,
         )
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Hey there! I am working on a [Maturin wheel](https://github.com/finos/perspective) built for abi3 and wasm32-emscripten-unknown, something which appears to work in Pyodide. I'm coming at this as a Rust developer, not really too knowledgable about Python, so most of what I know about abi3 is from the PyO3 documentation: https://pyo3.rs/v0.14.5/features.html#abi3

My understanding is that abi3 wheels are forwards compatible, meaning an abi3-py39 wheel will work with Python 3.9, 3.10, 3.11, 3.12, and so on. Empirically I can say our abi3-py39 wheel works just fine in Pyodide v0.26.2 (with some recent bugfixes I have recently done to perspective's build).

This PR adds support for abi3 wheels so that they can be added to pyodide-lock.json files. I added some test cases to test_wheel.py, happy to add more tests if needed elsewhere

abi3 is also known as the stable ABI https://docs.python.org/3/c-api/stable.html#stable-abi
