### PR TITLE
fix: output the mutated spec instead of the input spec

### DIFF
--- a/pyodide_lock/cli.py
+++ b/pyodide_lock/cli.py
@@ -47,11 +47,11 @@ def add_wheels(
 
     """
     sp = PyodideLockSpec.from_json(input)
-    add_wheels_to_spec(
+    new_sp = add_wheels_to_spec(
         sp,
         wheels,
         base_path=base_path,
         base_url=wheel_url,
         ignore_missing_dependencies=ignore_missing_dependencies,
     )
-    sp.to_json(output)
+    new_sp.to_json(output)


### PR DESCRIPTION
Currently, CLI invocations have no effect. The return value of `add_wheels_to_spec` is ignored, all that happens is that a copy of the source lockfile is written to the supplied output path.

This PR fixes that by writing the  result of `add_wheels_to_spec` to `output`.